### PR TITLE
Couple of tweaks to get it running again.

### DIFF
--- a/UpdatePCSX2.ps1
+++ b/UpdatePCSX2.ps1
@@ -1,7 +1,7 @@
 #Define PCSX2 path, repo url and version needed
 $runFolder = Split-Path $MyInvocation.MyCommand.Path -Parent
 $githubUrl = 'https://api.github.com/repos/PCSX2/pcsx2/releases'
-$releaseType = '*' + '64bit-AVX2.7z'
+$releaseType = '*' + '64bit-AVX2-wxWidgets.7z'
 
 function DownloadAndExtractNewVersion {
     param ([string]$DownloadUrl, [string]$Version)

--- a/readme.md
+++ b/readme.md
@@ -8,14 +8,14 @@
 - Install 7Zip4Powershell with `Install-Module -Name 7Zip4Powershell` in powershell console
 - Copy script to some directory on your machine  (PCSX2 folder or empty one)
 - change `$releaseType` to the one you need: 
-  - `32bit-AVX2-symbols.7z`
-  - `32bit-AVX2.7z`
-  - `32bit-SSE4-symbols.7z`
-  - `32bit-SSE4.7z`
-  - `64bit-AVX2-symbols.7z`
-  - `64bit-AVX2.7z`
-  - `64bit-SSE4-symbols.7z`
-  - `64bit-SSE4.7z`
+  - `64bit-AVX2-Qt-symbols.7z`
+  - `64bit-AVX2-Qt.7z`
+  - `64bit-AVX2-wxWidgets-symbols.7z`
+  - `64bit-AVX2-wxWidgets.7z`
+  - `64bit-SSE4-Qt-symbols.7z`
+  - `64bit-SSE4-Qt.7z`
+  - `64bit-SSE4-wxWidgets-symbols.7z`
+  - `64bit-SSE4-wxWidgets.7z`
 - right click on script -> *Run with PowerShell*
 - ???
 - PROFIT


### PR DESCRIPTION
Hi there...

Figured I'd maintain this piece of code since I use it from time to time (and get some practice with git.)

- 32 bit versions of PCSX2 have been deprecated, so I've removed them from the readme.
- Two GUI framework options are available now (wxWidgets and Qt.) wxWidgets is the original GUI, and Qt is the newer one.
- Symbols have been re-added for each.
- Default in UpdatePCSX2.ps1 is still the same, the 7z file label has been edited.

Regards,
Adem.